### PR TITLE
Support custom sizes and fix banner not appearing on iOS

### DIFF
--- a/ios/RCTConvert+GADAdSize.m
+++ b/ios/RCTConvert+GADAdSize.m
@@ -1,3 +1,4 @@
+#import <CoreGraphics/CoreGraphics.h>
 #import "RCTConvert+GADAdSize.h"
 
 @implementation RCTConvert (GADAdSize)
@@ -23,8 +24,9 @@
         return kGADAdSizeSmartBannerPortrait;
     } else if ([adSize isEqualToString:@"smartBannerLandscape"]) {
         return kGADAdSizeSmartBannerLandscape;
-    }
-    else {
+    } else if (!CGSizeEqualToSize(CGSizeFromString(json), CGSizeZero)) {
+        return GADAdSizeFromCGSize(CGSizeFromString(json));
+    } else {
         return kGADAdSizeInvalid;
     }
 }

--- a/ios/RNDFPBannerView.m
+++ b/ios/RNDFPBannerView.m
@@ -58,7 +58,6 @@
         request.customTargeting = _customTargeting;
     }
 
-    NSLog(@"HELLO %@", request);
     [_bannerView loadRequest:request];
 }
 
@@ -80,10 +79,6 @@
 {
     if(![customTargeting isEqual:_customTargeting]) {
         _customTargeting = customTargeting;
-        if (_bannerView) {
-            [_bannerView removeFromSuperview];
-            [self loadBanner];
-        }
     }
 }
 


### PR DESCRIPTION
- Fix banner not showing up on iOS
- Avoid custom params doing a second `loadBanner` call
- Remove logging
- Add support for custom sizes on conversion class