### PR TITLE
Fixes compilation error when updating to google play services 15

### DIFF
--- a/android/src/main/java/com/sbugert/rnadmob/RNAdMobRewardedVideoAdModule.java
+++ b/android/src/main/java/com/sbugert/rnadmob/RNAdMobRewardedVideoAdModule.java
@@ -33,6 +33,7 @@ public class RNAdMobRewardedVideoAdModule extends ReactContextBaseJavaModule imp
     public static final String EVENT_AD_LEFT_APPLICATION = "rewardedVideoAdLeftApplication";
     public static final String EVENT_REWARDED = "rewardedVideoAdRewarded";
     public static final String EVENT_VIDEO_STARTED = "rewardedVideoAdVideoStarted";
+    public static final String EVENT_VIDEO_COMPLETED = "rewardedVideoAdVideoCompleted";
 
     RewardedVideoAd mRewardedVideoAd;
     String adUnitID;
@@ -73,6 +74,11 @@ public class RNAdMobRewardedVideoAdModule extends ReactContextBaseJavaModule imp
     @Override
     public void onRewardedVideoStarted() {
         sendEvent(EVENT_VIDEO_STARTED, null);
+    }
+
+    @Override
+    public void onRewardedVideoCompleted() {
+        sendEvent(EVENT_VIDEO_COMPLETED, null);
     }
 
     @Override


### PR DESCRIPTION
fixes:
```
nfl-rn/node_modules/react-native-admob/android/src/main/java/com/sbugert/rnadmob/RNAdMobRewardedVideoAdModule.java:25: error: RNAdMobRewardedVideoAdModule is not abstract and does not override abstract method onRewardedVideoCompleted() in RewardedVideoAdListener
public class RNAdMobRewardedVideoAdModule extends ReactContextBaseJavaModule implements RewardedVideoAdListener {
       ^
1 error

```