### PR TITLE
Uses UIManager.getViewManagerConfig to resolve warning

### DIFF
--- a/RNAdMobBanner.js
+++ b/RNAdMobBanner.js
@@ -27,7 +27,7 @@ class AdMobBanner extends Component {
   loadBanner() {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this._bannerView),
-      UIManager.RNGADBannerView.Commands.loadBanner,
+      UIManager.getViewManagerConfig('RNGADBannerView').Commands.loadBanner,
       null,
     );
   }


### PR DESCRIPTION
https://github.com/sbugert/react-native-admob/issues/420

Change to UIManager.RNDFPBannerView.Commands.loadBanner, to UIManager.getViewManagerConfig('RNGADBannerView').Commands.loadBanner