### PR TITLE
Uses UIManager.getViewManagerConfig to resolve warning

### DIFF
--- a/RNAdMobBanner.js
+++ b/RNAdMobBanner.js
@@ -27,7 +27,7 @@ class AdMobBanner extends Component {
   loadBanner() {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this._bannerView),
-      UIManager.RNGADBannerView.Commands.loadBanner,
+      UIManager.getViewManagerConfig('RNGADBannerView').Commands.loadBanner,
       null,
     );
   }

--- a/RNPublisherBanner.js
+++ b/RNPublisherBanner.js
@@ -28,7 +28,7 @@ class PublisherBanner extends Component {
   loadBanner() {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this._bannerView),
-      UIManager.RNDFPBannerView.Commands.loadBanner,
+      UIManager.getViewManagerConfig('RNDFPBannerView').Commands.loadBanner,
       null,
     );
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nfl/react-native-admob",
-  "version": "2.0.0-beta.6-174d904",
+  "version": "2.0.0-beta.7-23bec84",
   "description": "A react-native component for Google AdMob banners and interstitials",
   "author": "Simon Bugert <simon.bugert@gmail.com>",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nfl/react-native-admob",
-  "version": "2.0.0-beta.7-23bec84",
+  "version": "2.0.1",
   "description": "A react-native component for Google AdMob banners and interstitials",
   "author": "Simon Bugert <simon.bugert@gmail.com>",
   "main": "index.js",


### PR DESCRIPTION
https://github.com/sbugert/react-native-admob/issues/420

Change to UIManager.RNDFPBannerView.Commands.loadBanner, to UIManager.getViewManagerConfig('RNGADBannerView').Commands.loadBanner

Unfortunately, this is not in https://github.com/sbugert/react-native-admob/blob/master/RNAdMobBanner.js#L30.